### PR TITLE
Fix websocket readyState on server close

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -83,7 +83,7 @@ class Server extends EventTarget {
     const listeners = networkBridge.websocketsLookup(this.url);
 
     listeners.forEach(socket => {
-      socket.readyState = WebSocket.CLOSE;
+      socket.readyState = WebSocket.CLOSED;
       socket.dispatchEvent(createCloseEvent({
         type: 'close',
         target: socket,

--- a/test/issue-74-test.js
+++ b/test/issue-74-test.js
@@ -1,0 +1,19 @@
+import assert from 'assert';
+import Server from '../src/server';
+import WebSocket from '../src/websocket';
+
+describe('Issue #74: Calling closed from server sets clients readyState to undefined', () => {
+  it('calling close on server sets client readyState to WebSocket.CLOSED', done => {
+    const server = new Server('ws://localhost:8080');
+    const socket = new WebSocket('ws://localhost:8080');
+
+    socket.onopen = function open() {
+      server.close();
+    };
+
+    socket.onclose = function close() {
+      assert.equal(socket.readyState, WebSocket.CLOSED, 'socket readyState is not closed');
+      done();
+    };
+  });
+});


### PR DESCRIPTION
Simple fix, `WebSocket.CLOSE` should be `WebSocket.CLOSED`, which was
causing readyState to get set to undefined when issuing server-side
close event.

Resolves #74
