### PR TITLE
Adding client verification to Server.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -20,7 +20,7 @@ class Server extends EventTarget {
   /*
   * @param {string} url
   */
-  constructor(url) {
+  constructor(url, options = {}) {
     super();
     this.url = normalize(url);
     const server = networkBridge.attachServer(this, this.url);
@@ -29,6 +29,10 @@ class Server extends EventTarget {
       this.dispatchEvent(createEvent({ type: 'error' }));
       throw new Error('A mock server is already listening on this url');
     }
+
+    this.options = Object.assign({
+      verifiyClient: null,
+    }, options);
 
     this.start();
   }

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -94,9 +94,20 @@ class WebSocket extends EventTarget {
     */
     delay(function delayCallback() {
       if (server) {
-        this.readyState = WebSocket.OPEN;
-        server.dispatchEvent(createEvent({ type: 'connection' }), server, this);
-        this.dispatchEvent(createEvent({ type: 'open', target: this }));
+        if (server.options.verifyClient && typeof server.options.verifyClient === 'function' && !server.options.verifyClient()) {
+          this.readyState = WebSocket.CLOSED;
+
+          /* eslint-disable no-console */
+          console.error(`WebSocket connection to '${this.url}' failed: HTTP Authentication failed; no valid credentials available`);
+          /* eslint-enable no-console */
+
+          this.dispatchEvent(createEvent({ type: 'error', target: this }));
+          this.dispatchEvent(createCloseEvent({ type: 'close', target: this, code: CLOSE_CODES.CLOSE_NORMAL }));
+        } else {
+          this.readyState = WebSocket.OPEN;
+          server.dispatchEvent(createEvent({ type: 'connection' }), server, this);
+          this.dispatchEvent(createEvent({ type: 'open', target: this }));
+        }
       } else {
         this.readyState = WebSocket.CLOSED;
         this.dispatchEvent(createEvent({ type: 'error', target: this }));

--- a/test/functional-websockets-test.js
+++ b/test/functional-websockets-test.js
@@ -26,6 +26,30 @@ describe('Functional - WebSockets', function functionalTest() {
     };
   });
 
+  it('that failing the verifyClient check invokes the onerror method', done => {
+    const server = new Server('ws://localhost:8080', {
+      verifyClient: () => false
+    });
+    const mockSocket = new WebSocket('ws://localhost:8080');
+
+    mockSocket.onerror = function open(event) {
+      assert.equal(event.target.readyState, WebSocket.CLOSED, 'onerror fires as expected');
+      done();
+    };
+  });
+
+  it('that verifyClient is only invoked if it is a function', done => {
+    const server = new Server('ws://localhost:8080', {
+      verifyClient: false
+    });
+    const mockSocket = new WebSocket('ws://localhost:8080');
+
+    mockSocket.onopen = function open(event) {
+      assert.equal(event.target.readyState, WebSocket.OPEN, 'onopen fires as expected');
+      done();
+    };
+  });
+
   it('that onmessage is called after the server sends a message', done => {
     const test = new Server('ws://localhost:8080');
 


### PR DESCRIPTION
This PR adds the ability to simulate client authentication for native WebSockets.

- Server now takes an `options` Object as a second parameter. ([src](https://github.com/thoov/mock-socket/compare/master...ccummings:add-client-verification?expand=1#diff-e6a5b42b2f7a26c840607370aed5301aR23))
- If the `verifyClient` option is provided, it will be invoked on each client's connection attempt. If it returns falsy; the connection is closed and onerror is triggered. ([src](https://github.com/thoov/mock-socket/compare/master...ccummings:add-client-verification?expand=1#diff-7cd41e7e5548228ba13f537ea2a76a20R97))
`verifyClient` should return a boolean
- If the `verifyClient` option is missing, Server and WebSocket behave like before