### PR TITLE
Allow emit to sent multiple arguments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,3 +9,4 @@ rules:
   no-param-reassign: 0
   import/no-extraneous-dependencies: 0
   no-undef: 0
+  prefer-rest-params: 0

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "test": "tests"
   },
   "scripts": {
-    "start": "./node_modules/broccoli-cli/bin/broccoli serve",
     "test": "BABEL_ENV=test babel-node ./node_modules/.bin/isparta cover _mocha",
     "build": "rm -rf dist; broccoli build dist",
     "lint": "eslint src tests Brocfile.js",
@@ -39,7 +38,6 @@
     "broccoli-cli": "~1.0.0",
     "broccoli-merge-trees": "~1.1.0",
     "codeclimate-test-reporter": "^0.3.3",
-    "del": "~2.2.0",
     "eslint": "^3.2.2",
     "eslint-config-airbnb-base": "^5.0.1",
     "eslint-plugin-import": "^1.12.0",

--- a/src/server.js
+++ b/src/server.js
@@ -95,15 +95,26 @@ class Server extends EventTarget {
       websockets = networkBridge.websocketsLookup(this.url);
     }
 
+    if (typeof options !== 'object' || arguments.length > 3) {
+      data = Array.prototype.slice.call(arguments, 1, arguments.length);
+    }
+
     websockets.forEach(socket => {
-      socket.dispatchEvent(
-        createMessageEvent({
+      if (Array.isArray(data)) {
+        socket.dispatchEvent(createMessageEvent({
           type: event,
           data,
           origin: this.url,
           target: socket,
-        })
-      );
+        }), ...data);
+      } else {
+        socket.dispatchEvent(createMessageEvent({
+          type: event,
+          data,
+          origin: this.url,
+          target: socket,
+        }));
+      }
     });
   }
 

--- a/src/socket-io.js
+++ b/src/socket-io.js
@@ -104,7 +104,7 @@ class SocketIO extends EventTarget {
   /*
   * Submits an event to the server with a payload
   */
-  emit(event, data) {
+  emit(event, ...data) {
     if (this.readyState !== SocketIO.OPEN) {
       throw new Error('SocketIO is already in CLOSING or CLOSED state');
     }
@@ -118,7 +118,7 @@ class SocketIO extends EventTarget {
     const server = networkBridge.serverLookup(this.url);
 
     if (server) {
-      server.dispatchEvent(messageEvent, data);
+      server.dispatchEvent(messageEvent, ...data);
     }
   }
 

--- a/test/functional-socket-io-test.js
+++ b/test/functional-socket-io-test.js
@@ -139,4 +139,37 @@ describe('Functional - SocketIO', function functionalTest() {
       server.to('room').emit('good-response');
     });
   });
+
+  it('Client can emit with multiple arguments', done => {
+    const server = new Server('foobar');
+    server.on('client-event', (...data) => {
+      assert.equal(data.length, 3);
+      assert.equal(data[0], 'foo');
+      assert.equal(data[1], 'bar');
+      assert.equal(data[2], 'baz');
+      server.close();
+      done();
+    });
+
+    const socket = io('foobar');
+    socket.on('connect', () => {
+      socket.emit('client-event', 'foo', 'bar', 'baz');
+    });
+  });
+
+  it('Server can emit with multiple arguments', done => {
+    const server = new Server('foobar');
+    server.on('connection', () => {
+      server.emit('server-emit', 'foo', 'bar');
+    });
+
+    const socket = io('foobar');
+    socket.on('server-emit', (...data) => {
+      assert.equal(data.length, 2);
+      assert.equal(data[0], 'foo');
+      assert.equal(data[1], 'bar');
+      server.close();
+      done();
+    });
+  });
 });

--- a/test/unit-event-target-test.js
+++ b/test/unit-event-target-test.js
@@ -69,4 +69,21 @@ describe('Unit - EventTarget', function unitTest() {
 
     assert.equal(mock.listeners.message.length, 2);
   });
+
+  it('that dispatching an event with multiple data arguments works correctly', () => {
+    const mock = new Mock();
+    const eventObject = createEvent({
+      type: 'message',
+    });
+
+    const fooListener = (...data) => {
+      assert.equal(data.length, 3);
+      assert.equal(data[0], 'foo');
+      assert.equal(data[1], 'bar');
+      assert.equal(data[2], 'baz');
+    };
+
+    mock.addEventListener('message', fooListener);
+    mock.dispatchEvent(eventObject, 'foo', 'bar', 'baz');
+  });
 });


### PR DESCRIPTION
socket.emit('event-name', 'foo', 'bar', 'baz') is now supported.

Fixes: #81 