### PR TITLE
removing websocket from network bridge if verifyClient fails

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -101,6 +101,7 @@ class WebSocket extends EventTarget {
           console.error(`WebSocket connection to '${this.url}' failed: HTTP Authentication failed; no valid credentials available`);
           /* eslint-enable no-console */
 
+          networkBridge.removeWebSocket(this, this.url);
           this.dispatchEvent(createEvent({ type: 'error', target: this }));
           this.dispatchEvent(createCloseEvent({ type: 'close', target: this, code: CLOSE_CODES.CLOSE_NORMAL }));
         } else {

--- a/test/functional-websockets-test.js
+++ b/test/functional-websockets-test.js
@@ -38,6 +38,20 @@ describe('Functional - WebSockets', function functionalTest() {
     };
   });
 
+  it('that failing the verifyClient check removes the websocket from the networkBridge', done => {
+    const server = new Server('ws://localhost:8080', {
+      verifyClient: () => false
+    });
+    const mockSocket = new WebSocket('ws://localhost:8080');
+   
+    mockSocket.onclose = function close() {
+       const urlMap = networkBridge.urlMap['ws://localhost:8080/'];
+      assert.equal(urlMap.websockets.length, 0, 'the websocket was removed from the network bridge');
+      server.close();
+      done();
+    };
+  });
+
   it('that verifyClient is only invoked if it is a function', done => {
     const server = new Server('ws://localhost:8080', {
       verifyClient: false


### PR DESCRIPTION
This bug was introduced by my previous PR (#82 ) where I added client auth.

If the `verifyClient` check fails, the websocket closes but does not remove the websocket from the network bridge.