### PR TITLE
Fix bug in 'Server.close()' where clients were notified before server was removed

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -139,6 +139,10 @@ class Server extends EventTarget {
     const { code, reason, wasClean } = options;
     const listeners = networkBridge.websocketsLookup(this.url);
 
+    // Remove server before notifications to prevent immediate reconnects from
+    // socket onclose handlers
+    networkBridge.removeServer(this.url);
+
     listeners.forEach(socket => {
       socket.readyState = WebSocket.CLOSE;
       socket.dispatchEvent(
@@ -153,7 +157,6 @@ class Server extends EventTarget {
     });
 
     this.dispatchEvent(createCloseEvent({ type: 'close' }), this);
-    networkBridge.removeServer(this.url);
   }
 
   /*


### PR DESCRIPTION
If after calling `Server.close()`, a websocket client's `onclose` handler immediately attempts to reconnect, then the connection will succeed because the server had not been removed before the notifications were sent.

I wonder if it might not be better, in general, to use `setTimeout(fn, 0)` to send notifications on the next event loop to prevent timing issues like this between the server and client.