### PR TITLE
Issue 143 :: Reassigning listeners on MockSocket

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -88,6 +88,22 @@ class WebSocket extends EventTarget {
     }, this);
   }
 
+  /*
+  * Ties a listener function to an event type which can later be invoked via the
+  * dispatchEvent method.
+  * This method will replace all existing listeners with the given listener.
+  *
+  * @param {string} type - the type of event (ie: 'open', 'message', etc.)
+  * @param {function} listener - the callback function to invoke whenever an event is dispatched matching the given type
+  */
+  replaceEventListener(type, listener) {
+    if (typeof listener === 'function') {
+      this.listeners[type] = [listener];
+    } else if (listener === null) {
+      this.listeners[type] = [];
+    }
+  }
+
   get onopen() {
     return this.listeners.open;
   }
@@ -105,19 +121,19 @@ class WebSocket extends EventTarget {
   }
 
   set onopen(listener) {
-    this.listeners.open = [listener];
+    this.replaceEventListener('open', listener);
   }
 
   set onmessage(listener) {
-    this.listeners.message = [listener];
+    this.replaceEventListener('message', listener);
   }
 
   set onclose(listener) {
-    this.listeners.close = [listener];
+    this.replaceEventListener('close', listener);
   }
 
   set onerror(listener) {
-    this.listeners.error = [listener];
+    this.replaceEventListener('error', listener);
   }
 
   /*

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -88,22 +88,6 @@ class WebSocket extends EventTarget {
     }, this);
   }
 
-  /*
-  * Ties a listener function to an event type which can later be invoked via the
-  * dispatchEvent method.
-  * This method will replace all existing listeners with the given listener.
-  *
-  * @param {string} type - the type of event (ie: 'open', 'message', etc.)
-  * @param {function} listener - the callback function to invoke whenever an event is dispatched matching the given type
-  */
-  replaceEventListener(type, listener) {
-    if (typeof listener === 'function') {
-      this.listeners[type] = [listener];
-    } else if (listener === null) {
-      this.listeners[type] = [];
-    }
-  }
-
   get onopen() {
     return this.listeners.open;
   }
@@ -121,19 +105,23 @@ class WebSocket extends EventTarget {
   }
 
   set onopen(listener) {
-    this.replaceEventListener('open', listener);
+    delete this.listeners.open;
+    this.addEventListener('open', listener);
   }
 
   set onmessage(listener) {
-    this.replaceEventListener('message', listener);
+    delete this.listeners.message;
+    this.addEventListener('message', listener);
   }
 
   set onclose(listener) {
-    this.replaceEventListener('close', listener);
+    delete this.listeners.close;
+    this.addEventListener('close', listener);
   }
 
   set onerror(listener) {
-    this.replaceEventListener('error', listener);
+    delete this.listeners.error;
+    this.addEventListener('error', listener);
   }
 
   /*

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -105,19 +105,19 @@ class WebSocket extends EventTarget {
   }
 
   set onopen(listener) {
-    this.addEventListener('open', listener);
+    this.listeners.open = [listener];
   }
 
   set onmessage(listener) {
-    this.addEventListener('message', listener);
+    this.listeners.message = [listener];
   }
 
   set onclose(listener) {
-    this.addEventListener('close', listener);
+    this.listeners.close = [listener];
   }
 
   set onerror(listener) {
-    this.addEventListener('error', listener);
+    this.listeners.error = [listener];
   }
 
   /*

--- a/tests/issues/143.test.js
+++ b/tests/issues/143.test.js
@@ -90,5 +90,24 @@ test.cb('reassigning websocket onerror listener should replace previous listener
 
   t.false(firstListenerCalled, 'The first listener should not be called');
   t.true(secondListenerCalled, 'Only the second listener should be called');
+  mockServer.close();
+  t.end();
+});
+
+test.cb('reassigning websocket null listener should clear previous listeners', t => {
+  const socketUrl = 'ws://localhost:8080';
+  const mockServer = new Server(socketUrl);
+  const mockSocket = new WebSocket(socketUrl);
+
+  let listenerCalled = false;
+
+  mockSocket.onerror = () => {
+    listenerCalled = true;
+  };
+  mockSocket.onerror = null;
+
+  mockServer.simulate('error');
+
+  t.false(listenerCalled, 'The first listener should not be called');
   t.end();
 });

--- a/tests/issues/143.test.js
+++ b/tests/issues/143.test.js
@@ -1,0 +1,94 @@
+import test from 'ava';
+import Server from '../../src/server';
+import WebSocket from '../../src/websocket';
+
+test.cb('reassigning websocket onopen listener should replace previous listeners', t => {
+  const socketUrl = 'ws://localhost:8080';
+  const mockServer = new Server(socketUrl);
+  const mockSocket = new WebSocket(socketUrl);
+
+  let firstListenerCalled = false;
+  let secondListenerCalled = false;
+
+  mockSocket.onopen = () => {
+    firstListenerCalled = true;
+  };
+  mockSocket.onopen = () => {
+    secondListenerCalled = true;
+  };
+
+  setTimeout(() => {
+    t.false(firstListenerCalled, 'The first listener should not be called');
+    t.true(secondListenerCalled, 'Only the second listener should be called');
+    mockServer.close();
+    t.end();
+  }, 500);
+});
+
+test.cb('reassigning websocket onmessage listener should replace previous listeners', t => {
+  const socketUrl = 'ws://localhost:8080';
+  const mockServer = new Server(socketUrl);
+  const mockSocket = new WebSocket(socketUrl);
+
+  let firstListenerCalled = false;
+  let secondListenerCalled = false;
+
+  mockSocket.onmessage = () => {
+    firstListenerCalled = true;
+  };
+  mockSocket.onmessage = () => {
+    secondListenerCalled = true;
+  };
+
+  mockServer.on('connection', () => {
+    mockServer.send('test message');
+    t.false(firstListenerCalled, 'The first listener should not be called');
+    t.true(secondListenerCalled, 'Only the second listener should be called');
+    mockServer.close();
+    t.end();
+  });
+});
+
+test.cb('reassigning websocket onclose listener should replace previous listeners', t => {
+  const socketUrl = 'ws://localhost:8080';
+  const mockServer = new Server(socketUrl);
+  const mockSocket = new WebSocket(socketUrl);
+
+  let firstListenerCalled = false;
+  let secondListenerCalled = false;
+
+  mockSocket.onclose = () => {
+    firstListenerCalled = true;
+  };
+  mockSocket.onclose = () => {
+    secondListenerCalled = true;
+  };
+
+  mockServer.close();
+
+  t.false(firstListenerCalled, 'The first listener should not be called');
+  t.true(secondListenerCalled, 'Only the second listener should be called');
+  t.end();
+});
+
+test.cb('reassigning websocket onerror listener should replace previous listeners', t => {
+  const socketUrl = 'ws://localhost:8080';
+  const mockServer = new Server(socketUrl);
+  const mockSocket = new WebSocket(socketUrl);
+
+  let firstListenerCalled = false;
+  let secondListenerCalled = false;
+
+  mockSocket.onerror = () => {
+    firstListenerCalled = true;
+  };
+  mockSocket.onerror = () => {
+    secondListenerCalled = true;
+  };
+
+  mockServer.simulate('error');
+
+  t.false(firstListenerCalled, 'The first listener should not be called');
+  t.true(secondListenerCalled, 'Only the second listener should be called');
+  t.end();
+});


### PR DESCRIPTION
Hello !

This PR is to fix https://github.com/thoov/mock-socket/issues/143
Currently, the behaviour of mockSocket does not match websocket behaviour : reassigning a listener does not cancel previous listeners.

I implemented the workaround proposed in the issue.