### PR TITLE
Passing protocol through instantiation code

### DIFF
--- a/src/socket-io.js
+++ b/src/socket-io.js
@@ -29,7 +29,7 @@ class SocketIO extends EventTarget {
     this.readyState = SocketIO.CONNECTING;
     this.protocol = '';
 
-    if (typeof protocol === 'string') {
+    if (typeof protocol === 'string' || (typeof protocol === 'object' && protocol !== null)) {
       this.protocol = protocol;
     } else if (Array.isArray(protocol) && protocol.length > 0) {
       this.protocol = protocol[0];
@@ -256,16 +256,16 @@ SocketIO.CLOSED = 3;
 /*
 * Static constructor methods for the IO Socket
 */
-const IO = function ioConstructor(url) {
-  return new SocketIO(url);
+const IO = function ioConstructor(url, protocol) {
+  return new SocketIO(url, protocol);
 };
 
 /*
 * Alias the raw IO() constructor
 */
-IO.connect = function ioConnect(url) {
+IO.connect = function ioConnect(url, protocol) {
   /* eslint-disable new-cap */
-  return IO(url);
+  return IO(url, protocol);
   /* eslint-enable new-cap */
 };
 

--- a/tests/unit/socket-io.test.js
+++ b/tests/unit/socket-io.test.js
@@ -12,9 +12,22 @@ test('it accepts a url', t => {
   t.truthy(socket);
 });
 
-test('it accepts an opts object paramter', t => {
-  const socket = io('http://localhost', { a: 'apple' });
+test('it accepts an opts object parameter', t => {
+  const protocol = { a: 'apple' };
+  const socket = io('http://localhost', protocol);
   t.truthy(socket);
+  t.is(socket.protocol, protocol);
+});
+
+test.cb('it includes opts object parameter in server connection callback', t => {
+  const url = 'ws://not-real/';
+  const myServer = new Server(url);
+  const protocol = { a: 'apple' };
+  const socket = io(url, protocol);
+  myServer.on('connection', (server, instance) => {
+    t.is(instance.protocol, protocol);
+    t.end();
+  });
 });
 
 test('it can equivalently use a connect method', t => {


### PR DESCRIPTION
- Passing through `protocol` option to SocketIo instance.

Fixes https://github.com/thoov/mock-socket/issues/201