### PR TITLE
Fix types to fit noImplicitAny option.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -44,7 +44,7 @@ declare module 'mock-socket' {
 
     clients(): WebSocket[];
     to(room: any, broadcaster: any, broadcastList: object): ToReturnObject;
-    in(any): ToReturnObject;
+    in(any: any): ToReturnObject;
     simulate(event: Event): void;
 
     public of(url: USVString): Server;


### PR DESCRIPTION
This provides a fix to error below:
```.../node_modules/mock-socket/index.d.ts
(47,8): Parameter 'any' implicitly has an 'any' type.
```