### PR TITLE
Check for `process.env` before accessing `process.env.NODE_ENV`, fixes #228

### DIFF
--- a/src/helpers/logger.js
+++ b/src/helpers/logger.js
@@ -1,6 +1,6 @@
 export default function log(method, message) {
   /* eslint-disable no-console */
-  if (typeof process !== 'undefined' && process.env.NODE_ENV !== 'test') {
+  if (process && process.env && process.env.NODE_ENV !== 'test') {
     console[method].call(null, message);
   }
   /* eslint-enable no-console */


### PR DESCRIPTION
#228