### PR TITLE
Support socket.io connections with query params

### DIFF
--- a/src/socket-io.js
+++ b/src/socket-io.js
@@ -24,6 +24,9 @@ class SocketIO extends EventTarget {
     if (!urlRecord.pathname) {
       urlRecord.pathname = '/';
     }
+    if (urlRecord.query !== '') {
+      urlRecord.query = '';
+    }
 
     this.url = urlRecord.toString();
     this.readyState = SocketIO.CONNECTING;

--- a/src/socket-io.js
+++ b/src/socket-io.js
@@ -6,6 +6,18 @@ import { CLOSE_CODES } from './constants';
 import logger from './helpers/logger';
 import { createEvent, createMessageEvent, createCloseEvent } from './event/factory';
 
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+function isEmptyObject(object) {
+  // eslint-disable-next-line no-restricted-syntax
+  for (const key in object) {
+    if (hasOwnProperty.call(object, key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
 /*
  * The socket-io class is designed to mimick the real API as closely as possible.
  *
@@ -19,12 +31,18 @@ class SocketIO extends EventTarget {
     super();
 
     this.binaryType = 'blob';
-    const urlRecord = new URL(url);
+    const urlRecord = new URL(url, true);
 
     if (!urlRecord.pathname) {
       urlRecord.pathname = '/';
     }
-    if (urlRecord.query !== '') {
+
+    this.query = urlRecord.query;
+
+    if (
+      (typeof urlRecord.query === 'string' && urlRecord.query.length) ||
+      (typeof urlRecord.query === 'object' && !isEmptyObject(urlRecord.query))
+    ) {
       urlRecord.query = '';
     }
 

--- a/tests/unit/socket-io.test.js
+++ b/tests/unit/socket-io.test.js
@@ -83,3 +83,12 @@ test.cb.skip('it can broadcast to other connected sockets in a room', t => {
     t.end();
   });
 });
+
+test.cb('it removes query parameters', t => {
+  const myServer = new Server('ws://not-real/');
+  const socket = io('ws://not-real/?a=1');
+  myServer.on('connection', (server, instance) => {
+    myServer.close();
+    t.end();
+  });
+});

--- a/tests/unit/socket-io.test.js
+++ b/tests/unit/socket-io.test.js
@@ -92,3 +92,13 @@ test.cb('it removes query parameters', t => {
     t.end();
   });
 });
+
+test.cb('it includes query object parameter in server connection callback', t => {
+  const myServer = new Server('ws://not-real/');
+  const socket = io('ws://not-real/?a=1&b=2');
+  myServer.on('connection', (server, instance) => {
+    t.deepEqual(instance.query, { a: '1', b: '2' });
+    myServer.close();
+    t.end();
+  });
+});

--- a/tests/unit/socket-io.test.js
+++ b/tests/unit/socket-io.test.js
@@ -26,6 +26,7 @@ test.cb('it includes opts object parameter in server connection callback', t => 
   const socket = io(url, protocol);
   myServer.on('connection', (server, instance) => {
     t.is(instance.protocol, protocol);
+    myServer.close();
     t.end();
   });
 });


### PR DESCRIPTION
This is basically the same as #186, but updated to work against the current `master` branch.

When a socket.io connection is requested the URL is parsed as before, but now we also parse the query string and assign it to `this.query`, while also removing it from `this.url`. This allows the `Server` to match on the URL _without_ taking the query parameters into account.

My particular use case is that I have a socket.io server which implements request signing via HMAC. This means my client library passes a signed URL to `io.connect`, which `mock-socket` isn't able to correlate to a `Server` instance because the URLs aren't exact string matches.