### PR TITLE
Fix Typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare module 'mock-socket' {
     readonly OPEN: 1;
     readonly CLOSING: 2;
     readonly CLOSED: 3;
-    readonly readState: number;
+    readonly readyState: number;
     readonly bufferedAmount: number;
 
     onopen: EventHandlerNonNull;
@@ -36,14 +36,14 @@ declare module 'mock-socket' {
     readonly options?: ServerOptions;
 
     start(): void;
-    stop(callback: () => void): void;
+    stop(callback?: () => void): void;
 
     on(type: string, callback: (socket: WebSocket) => void): void;
-    close(options: CloseOptions): void;
-    emit(event: Event, data: any, options: EmitOptions): void;
+    close(options?: CloseOptions): void;
+    emit(event: string, data: any, options?: EmitOptions): void;
 
     clients(): WebSocket[];
-    to(room: any, broadcaster: any, broadcastList: object): ToReturnObject;
+    to(room: any, broadcaster: any, broadcastList?: object): ToReturnObject;
     in(any: any): ToReturnObject;
     simulate(event: Event): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,6 +3,13 @@
 // Definitions by: Travis Hoover <https://github.com/thoov/mock-socket>
 
 declare module 'mock-socket' {
+  class EventTarget {
+    listeners: any;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
+    dispatchEvent(evt: Event): boolean;
+    removeEventListener(type: string, listener?: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
+  }
+
   //
   // https://html.spec.whatwg.org/multipage/web-sockets.html#websocket
   //


### PR DESCRIPTION
Fixed some type errors I ran into when using Typescript:

- added types for *EventTarget* (*listeners*)

- types now reflect options for server's *close()* and *emit()* methods being optional

- fixed typo in *readyState*, addresses #230

- ...