### PR TITLE
Do not run normalizeSendData in Server when using SocketIO websockets

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 import URL from 'url-parse';
 import WebSocket from './websocket';
+import IO, { SocketIO } from './socket-io';
 import dedupe from './helpers/dedupe';
 import EventTarget from './event/target';
 import { CLOSE_CODES } from './constants';
@@ -126,11 +127,16 @@ class Server extends EventTarget {
       websockets = networkBridge.websocketsLookup(this.url);
     }
 
-    if (typeof options !== 'object' || arguments.length > 3) {
-      data = Array.prototype.slice.call(arguments, 1, arguments.length);
-      data = data.map(item => normalizeSendData(item));
-    } else {
-      data = normalizeSendData(data);
+    let isSocketIO = websockets.some(websocket => websocket instanceof SocketIO);
+    if (! isSocketIO) {
+      // only normalize data for plain WebSockets
+      // SocketIO handles deserialization of objects
+      if (typeof options !== 'object' || arguments.length > 3) {
+        data = Array.prototype.slice.call(arguments, 1, arguments.length);
+        data = data.map(item => normalizeSendData(item));
+      } else {
+        data = normalizeSendData(data);
+      }
     }
 
     websockets.forEach(socket => {

--- a/src/socket-io.js
+++ b/src/socket-io.js
@@ -11,7 +11,7 @@ import { createEvent, createMessageEvent, createCloseEvent } from './event/facto
 *
 * http://socket.io/docs/
 */
-class SocketIO extends EventTarget {
+export class SocketIO extends EventTarget {
   /*
   * @param {string} url
   */
@@ -277,3 +277,4 @@ IO.connect = function ioConnect(url, protocol) {
 };
 
 export default IO;
+


### PR DESCRIPTION
In Server.emit, do not run normalizeSendData to convert to string if the websockets are SocketIO sockets.  The SocketIO API handles deserializing to objects.

I was using mock-socket for unit tests for a client that is using Socket IO.  The live code receives an object as argument to socket.on.  Using mock-socket the object was getting encoded to string "[object Object]".  Skipping the normalizeSendData mimicks the SocketIO's deserialization by returning the object unchanged.