### PR TITLE
Fix type for Server.simulate argument

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,7 +57,7 @@ declare module 'mock-socket' {
     clients(): WebSocket[];
     to(room: any, broadcaster: any, broadcastList?: object): ToReturnObject;
     in(any: any): ToReturnObject;
-    simulate(event: Event): void;
+    simulate(event: string): void;
 
     public of(url: string): Server;
   }


### PR DESCRIPTION
Currently, if you try to pass 'error' as the event argument, Typescript marks it as an error since it isn't an Event object. This PR changes the argument type to string to match the correct usage.