### PR TITLE
[IMPR] Typescript WebSocket missing proxyFactory "on" wrapper

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,13 @@ declare module 'mock-socket' {
     removeEventListener(type: string, listener?: EventListenerOrEventListenerObject | null, options?: EventListenerOptions | boolean): void;
   }
 
+  interface WebSocketCallbackMap {
+    close: () => void;
+    error: (err: Error) => void;
+    message: (message: string | Blob | ArrayBuffer | ArrayBufferView) => void;
+    open: () => void;
+  }
+
   //
   // https://html.spec.whatwg.org/multipage/web-sockets.html#websocket
   //
@@ -40,6 +47,7 @@ declare module 'mock-socket' {
     onmessage: EventHandlerNonNull;
     binaryType: BinaryType;
     send(data: string | Blob | ArrayBuffer | ArrayBufferView): void;
+    on<K extends keyof WebSocketCallbackMap>(type: K, callback: WebSocketCallbackMap[K]): void;
   }
 
   class Server extends EventTarget {


### PR DESCRIPTION
Hi, thanks a lot for this library!

It seems that the following code causes an error because the `WebSocket` type definition lacks the `on` method:
```typescript
mockServer.on('connection', (socket: WebSocket) => {
  socket.on('message', (data: string) => {
         ^^ Property 'on' does not exist on type 'WebSocket'.
    // noop
  })
})
```
This PR adds the missing `on` method using mapped values [as the official Typescript definition does](https://github.com/Microsoft/TypeScript/blob/v3.3.3333/lib/lib.dom.d.ts#L16355) but the following should also do:
```typescript
on(type: string, callback: (data: string | Blob | ArrayBuffer | ArrayBufferView) => void): void;
```
After all is seems that the code allows any types between the server and the client :smile: 