### PR TITLE
Export ES Module format with .mjs extension,

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,6 +10,7 @@ export default {
     { dest: 'dist/mock-socket.cjs.js', format: 'cjs' },
     { dest: 'dist/mock-socket.js', format: 'umd', moduleName: 'Mock' },
     { dest: 'dist/mock-socket.amd.js', format: 'amd', moduleName: 'Mock' },
-    { dest: 'dist/mock-socket.es.js', format: 'es' }
+    { dest: 'dist/mock-socket.es.js', format: 'es' },
+    { dest: 'dist/mock-socket.es.mjs', format: 'es' }
   ]
 };


### PR DESCRIPTION
as given lack of `"type": "module"` in `package.json`, and `.js` extension  Node tries to resolve `import "mock-socket/dist/mock-socket.es.js"` as CommonJS, and throws Syntax errors on `export`