### PR TITLE
Fix normalize-send when sending object data, add test

### DIFF
--- a/src/helpers/normalize-send.js
+++ b/src/helpers/normalize-send.js
@@ -1,5 +1,6 @@
 export default function normalizeSendData(data) {
-  if (Object.prototype.toString.call(data) !== '[object Blob]' && !(data instanceof ArrayBuffer)) {
+  const type = Object.prototype.toString.call(data);
+  if (type !== '[object Blob]' && !(data instanceof ArrayBuffer) && type !== '[object Object]') {
     data = String(data);
   }
 

--- a/tests/unit/server.test.js
+++ b/tests/unit/server.test.js
@@ -103,13 +103,20 @@ test.cb('that send will normalize data', t => {
 
   myServer.on('connection', socket => {
     socket.send([1, 2]);
+    socket.send({ foo: 'bar' });
   });
 
   const socketFoo = new WebSocket('ws://not-real/');
+  let counter = 0;
   socketFoo.onmessage = message => {
-    t.is(message.data, '1,2', 'data non string, non blob/arraybuffers get toStringed');
-    myServer.close();
-    t.end();
+    if (counter === 0) {
+      t.is(message.data, '1,2', 'data non string, non blob/arraybuffers get toStringed');
+      counter += 1;
+    } else if (counter === 1) {
+      t.is(message.data.foo, 'bar', 'object does not get toStringed');
+      myServer.close();
+      t.end();
+    }
   };
 });
 


### PR DESCRIPTION
* This should close https://github.com/thoov/mock-socket/issues/245
* However...I am not sure if this is actually desired behavior for non-socketIO clients - but I'm pretty sure the native browser WebSocket spec only supports sending stringified messages, so this is probably OK to merge