### PR TITLE
Fix null pointer exceptions

### DIFF
--- a/src/helpers/array-helpers.js
+++ b/src/helpers/array-helpers.js
@@ -1,4 +1,4 @@
-export function reject(array, callback) {
+export function reject(array = [], callback) {
   const results = [];
   array.forEach(itemInArray => {
     if (!callback(itemInArray)) {
@@ -9,7 +9,7 @@ export function reject(array, callback) {
   return results;
 }
 
-export function filter(array, callback) {
+export function filter(array = [], callback) {
   const results = [];
   array.forEach(itemInArray => {
     if (callback(itemInArray)) {


### PR DESCRIPTION
The current version triggers an NPE when one tries to unregister an event type (using `.off(...)`) that does not have any associated handlers.