### PR TITLE
Solve transversal path vulnerability in url-parse

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/thoov/mock-socket",
   "dependencies": {
-    "url-parse": "^1.4.4"
+    "url-parse": "^1.5.0"
   },
   "devDependencies": {
     "ava": "^0.19.1",


### PR DESCRIPTION
url-parse library has a transversal path vulnerability reported in:
https://github.com/advisories/GHSA-9m6j-fcg5-2442

Then, it's important increment the version used in mock-socket. 




