### PR TITLE
Update type of url parameter of websocket constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ declare module 'mock-socket' {
   // https://html.spec.whatwg.org/multipage/web-sockets.html#websocket
   //
   class WebSocket extends EventTarget {
-    constructor(url?: string, protocols?: string|string[]);
+    constructor(url?: string | URL, protocols?: string|string[]);
 
     static readonly CONNECTING: 0;
     static readonly OPEN: 1;

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ declare module 'mock-socket' {
   // https://html.spec.whatwg.org/multipage/web-sockets.html#websocket
   //
   class WebSocket extends EventTarget {
-    constructor(url?: string | URL, protocols?: string|string[]);
+    constructor(url: string | URL, protocols?: string|string[]);
 
     static readonly CONNECTING: 0;
     static readonly OPEN: 1;

--- a/tests/unit/websocket.test.js
+++ b/tests/unit/websocket.test.js
@@ -1,3 +1,4 @@
+import URL from 'url-parse';
 import test from 'ava';
 import WebSocket from '../../src/websocket';
 import EventTarget from '../../src/event/target';

--- a/tests/unit/websocket.test.js
+++ b/tests/unit/websocket.test.js
@@ -8,13 +8,13 @@ test.skip('that not passing a url throws an error', t => {
   }, "Failed to construct 'WebSocket': 1 argument required, but only 0 present");
 });
 
-test('that websockets inherents EventTarget methods', t => {
+test('that websockets inherents EventTarget methods with string type url', t => {
   const mySocket = new WebSocket('ws://not-real');
   t.true(mySocket instanceof EventTarget);
 });
 
-test('that websockets inherents EventTarget methods', t => {
-  const mySocket = new WebSocket('ws://not-real');
+test('that websockets inherents EventTarget methods with URL type url', t => {
+  const mySocket = new WebSocket(new URL('ws://not-real'));
   t.true(mySocket instanceof EventTarget);
 });
 

--- a/tests/unit/websocket.test.js
+++ b/tests/unit/websocket.test.js
@@ -15,7 +15,9 @@ test('that websockets inherents EventTarget methods with string type url', t => 
 
 test('that websockets inherents EventTarget methods with URL type url', t => {
   const mySocket = new WebSocket(new URL('ws://not-real'));
+
   t.true(mySocket instanceof EventTarget);
+  t.is(mySocket.url, 'ws://not-real/');
 });
 
 test('that on(open, message, error, and close) can be set', t => {


### PR DESCRIPTION
Typescript expects the url in the constructor of a websocket to be of type `string | URL` as seen here: https://github.com/microsoft/TypeScript/blob/main/lib/lib.dom.d.ts#L17136. Update types to reflect this.