### PR TITLE
trim query params for attachServer method lookup

### DIFF
--- a/src/network-bridge.js
+++ b/src/network-bridge.js
@@ -55,10 +55,11 @@ class NetworkBridge {
    * @param {string} url
    */
   attachServer(server, url) {
-    const connectionLookup = this.urlMap[url];
+    const serverUrl = trimQueryPartFromURL(url);
+    const connectionLookup = this.urlMap[serverUrl];
 
     if (!connectionLookup) {
-      this.urlMap[url] = {
+      this.urlMap[serverUrl] = {
         server,
         websockets: [],
         roomMemberships: {}


### PR DESCRIPTION
Apparently, [the fix](https://github.com/thoov/mock-socket/pull/275) for https://github.com/thoov/mock-socket/issues/274 was not complete.

These changes have to do the job.
Worked for me at least