### PR TITLE
Address misspelling of cancelBuble

### DIFF
--- a/src/event/event.js
+++ b/src/event/event.js
@@ -25,7 +25,7 @@ export default class Event extends EventPrototype {
     this.defaultPrevented = false;
     this.currentTarget = null;
     this.cancelable = cancelable ? Boolean(cancelable) : false;
-    this.canncelBubble = false;
+    this.cancelBubble = false;
     this.bubbles = bubbles ? Boolean(bubbles) : false;
   }
 }


### PR DESCRIPTION
I leave as an exercise to the developers to propose a regression test. I spotted this in the wild and assume it can’t be right, but have not investigated further. It is not a problem for our usage.