### PR TITLE
Fix: pass Buffer data type as ArrayBuffer instead of string

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,7 @@ declare module 'mock-socket' {
   class Server extends EventTarget {
     constructor(url: string, options?: ServerOptions);
 
+    readonly url: string;
     readonly options?: ServerOptions;
 
     stop(callback?: () => void): void;

--- a/src/helpers/normalize-send.js
+++ b/src/helpers/normalize-send.js
@@ -1,5 +1,7 @@
 export default function normalizeSendData(data) {
-  if (Object.prototype.toString.call(data) !== '[object Blob]' && !(data instanceof ArrayBuffer)) {
+  if (data instanceof Buffer) {
+    data = data.buffer;
+  } else if (Object.prototype.toString.call(data) !== '[object Blob]' && !(data instanceof ArrayBuffer)) {
     data = String(data);
   }
 


### PR DESCRIPTION
From what I experienced with web sockets, Buffer messages are transmitted as ArrayBuffer in the message event.

This modification may break some people implementations but should be closer to real behaviour.

Happy to have your feedback.