### PR TITLE
Ensure that the server side close event is fired on server shutdown

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -117,6 +117,15 @@ class Server extends EventTarget {
           wasClean
         })
       );
+      socket.dispatchEvent(
+        createCloseEvent({
+          type: 'server::close',
+          target: socket.target,
+          code: code || CLOSE_CODES.CLOSE_NORMAL,
+          reason: reason || '',
+          wasClean
+        })
+      );
     });
 
     this.dispatchEvent(createCloseEvent({ type: 'close' }), this);

--- a/tests/functional/websockets.test.js
+++ b/tests/functional/websockets.test.js
@@ -148,6 +148,25 @@ test.cb('that the server gets called when the client sends a message using URL w
   };
 });
 
+test.cb('that the server side socket\'s close event gets called when the server shuts down', t => {
+  const testServer = new Server('ws://localhost:8080');
+
+  testServer.on('connection', socket => {
+    socket.on('close', (event) => {
+      t.is(event.target.readyState, WebSocket.CLOSED, 'close event fires as expected');
+      t.end();
+    });
+  });
+
+  const mockSocket = new WebSocket('ws://localhost:8080');
+
+  mockSocket.onopen = function open() {
+    setTimeout(() => {
+      testServer.close();
+    }, 10);
+  };
+});
+
 test.cb('that the onopen function will only be called once for each client', t => {
   const socketUrl = 'ws://localhost:8080';
   const mockServer = new Server(socketUrl);


### PR DESCRIPTION
This fixes a bug where if a mock socket server is shut down explicitly with the `.close()` option, the clients are notified, but any server side close listeners are not. This ensures we fire both the client and server close events on shutdown instead.