### PR TITLE
Handle proxy events properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ const mockServer = new Server('ws://localhost:8080');
 mockServer.on('connection', socket => {
   socket.on('message', () => {});
   socket.on('close', () => {});
+  socket.on('error', () => {});
 
   socket.send('message');
   socket.close();

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,6 @@ declare module 'mock-socket' {
     close: () => void;
     error: (err: Error) => void;
     message: (message: string | Blob | ArrayBuffer | ArrayBufferView) => void;
-    open: () => void;
   }
 
   //
@@ -56,6 +55,7 @@ declare module 'mock-socket' {
     target: WebSocket;
     close(options?: CloseOptions): void;
     on<K extends keyof WebSocketCallbackMap>(type: K, callback: WebSocketCallbackMap[K]): void;
+    off<K extends keyof WebSocketCallbackMap>(type: K, callback: WebSocketCallbackMap[K]): void;
   }
 
   class Server extends EventTarget {
@@ -68,6 +68,7 @@ declare module 'mock-socket' {
     restoreWebsocket(): void;
 
     on(type: string, callback: (socket: Client) => void): void;
+    off(type: string, callback: (socket: Client) => void): void;
     close(options?: CloseOptions): void;
     emit(event: string, data: any, options?: EmitOptions): void;
 

--- a/src/algorithms/close.js
+++ b/src/algorithms/close.js
@@ -13,19 +13,12 @@ export function closeWebSocketConnection(context, code, reason) {
     code,
     reason
   });
-  const serverCloseEvent = createCloseEvent({
-    type: 'server::close',
-    target: context,
-    code,
-    reason
-  });
 
   delay(() => {
     networkBridge.removeWebSocket(context, context.url);
 
     context.readyState = WebSocket.CLOSED;
     context.dispatchEvent(closeEvent);
-    context.dispatchEvent(serverCloseEvent);
 
     if (server) {
       server.dispatchEvent(closeEvent, server);
@@ -44,13 +37,6 @@ export function failWebSocketConnection(context, code, reason) {
     reason,
     wasClean: false
   });
-  const serverCloseEvent = createCloseEvent({
-    type: 'server::close',
-    target: context,
-    code,
-    reason,
-    wasClean: false
-  });
 
   const errorEvent = createEvent({
     type: 'error',
@@ -63,7 +49,6 @@ export function failWebSocketConnection(context, code, reason) {
     context.readyState = WebSocket.CLOSED;
     context.dispatchEvent(errorEvent);
     context.dispatchEvent(closeEvent);
-    context.dispatchEvent(serverCloseEvent);
 
     if (server) {
       server.dispatchEvent(closeEvent, server);

--- a/src/helpers/proxy-factory.js
+++ b/src/helpers/proxy-factory.js
@@ -36,10 +36,15 @@ export default function proxyFactory(target) {
         };
       }
 
+      const toSocketName = type => (type === 'message' ? `server::${type}` : type);
       if (prop === 'on') {
         return function onWrapper(type, cb) {
-          type = type === 'message' ? `server::${type}` : type;
-          target.addEventListener(type, cb);
+          target.addEventListener(toSocketName(type), cb);
+        };
+      }
+      if (prop === 'off') {
+        return function offWrapper(type, cb) {
+          target.removeEventListener(toSocketName(type), cb);
         };
       }
 

--- a/src/helpers/proxy-factory.js
+++ b/src/helpers/proxy-factory.js
@@ -38,7 +38,8 @@ export default function proxyFactory(target) {
 
       if (prop === 'on') {
         return function onWrapper(type, cb) {
-          target.addEventListener(`server::${type}`, cb);
+          type = type === 'message' ? `server::${type}` : type;
+          target.addEventListener(type, cb);
         };
       }
 

--- a/src/server.js
+++ b/src/server.js
@@ -205,7 +205,7 @@ class Server extends EventTarget {
     if (event === 'error') {
       listeners.forEach(socket => {
         socket.readyState = WebSocket.CLOSED;
-        socket.dispatchEvent(createEvent({ type: 'error' }));
+        socket.dispatchEvent(createEvent({ type: 'error', target: socket.target }));
       });
     }
   }

--- a/src/server.js
+++ b/src/server.js
@@ -92,6 +92,13 @@ class Server extends EventTarget {
   }
 
   /*
+  * Remove event listener
+  */
+  off(type, callback) {
+    this.removeEventListener(type, callback);
+  }
+
+  /*
    * Closes the connection and triggers the onclose method of all listening
    * websockets. After that it removes itself from the urlMap so another server
    * could add itself to the url.

--- a/tests/functional/close-algorithm.test.js
+++ b/tests/functional/close-algorithm.test.js
@@ -4,7 +4,7 @@ import WebSocket from '../../src/websocket';
 import networkBridge from '../../src/network-bridge';
 import delay from '../../src/helpers/delay';
 
-test.afterEach(() => {
+test.beforeEach(() => {
   networkBridge.urlMap = {};
 });
 

--- a/tests/functional/websockets.test.js
+++ b/tests/functional/websockets.test.js
@@ -3,7 +3,7 @@ import Server from '../../src/server';
 import WebSocket from '../../src/websocket';
 import networkBridge from '../../src/network-bridge';
 
-test.afterEach(() => {
+test.beforeEach(() => {
   networkBridge.urlMap = {};
 });
 

--- a/tests/functional/websockets.test.js
+++ b/tests/functional/websockets.test.js
@@ -148,6 +148,48 @@ test.cb('that the server gets called when the client sends a message using URL w
   };
 });
 
+test.cb('that close event is handled both for the client and WebSocket when the server shuts down', t => {
+  t.plan(2);
+
+  const testServer = new Server('ws://localhost:8080');
+
+  testServer.on('connection', socket => {
+    socket.on('close', event => {
+      t.is(event.target.readyState, WebSocket.CLOSED, 'close event fires as expected in the client');
+      t.end();
+    });
+
+    testServer.close();
+  });
+
+  const mockSocket = new WebSocket('ws://localhost:8080');
+
+  mockSocket.onclose = event => {
+    t.is(event.target.readyState, WebSocket.CLOSED, 'close event fires as expected in the WebSocket');
+  };
+});
+
+test.cb('that error event is handled both for the client and WebSocket when the server emits error', t => {
+  t.plan(2);
+
+  const testServer = new Server('ws://localhost:8080');
+
+  testServer.on('connection', socket => {
+    socket.on('error', event => {
+      t.is(event.target.readyState, WebSocket.CLOSED, 'error event fires as expected on the client');
+      t.end();
+    });
+
+    testServer.simulate('error');
+  });
+
+  const mockSocket = new WebSocket('ws://localhost:8080');
+
+  mockSocket.onerror = event => {
+    t.is(event.target.readyState, WebSocket.CLOSED, 'error event fires as expected on the WebSocket');
+  };
+});
+
 test.cb('that the onopen function will only be called once for each client', t => {
   const socketUrl = 'ws://localhost:8080';
   const mockServer = new Server(socketUrl);

--- a/tests/unit/factory.test.js
+++ b/tests/unit/factory.test.js
@@ -4,8 +4,8 @@ import { createEvent, createMessageEvent, createCloseEvent } from '../../src/eve
 const fakeObject = { foo: 'bar' };
 
 test('that the create methods throw errors if no type if specified', t => {
-  t.throws(() => createEvent(), "Cannot read property 'type' of undefined");
-  t.throws(() => createMessageEvent(), "Cannot read property 'type' of undefined");
+  t.throws(() => createEvent(), error => error.name === 'TypeError');
+  t.throws(() => createMessageEvent(), error => error.name === 'TypeError');
 });
 
 test('that createEvent correctly creates an event', t => {

--- a/tests/unit/network-bridge.test.js
+++ b/tests/unit/network-bridge.test.js
@@ -4,7 +4,7 @@ import networkBridge from '../../src/network-bridge';
 
 const fakeObject = { foo: 'bar' };
 
-test.afterEach(() => {
+test.beforeEach(() => {
   networkBridge.urlMap = {};
 });
 

--- a/tests/unit/server.test.js
+++ b/tests/unit/server.test.js
@@ -20,14 +20,22 @@ test('that after creating a server it is added to the network bridge', t => {
   t.deepEqual(networkBridge.urlMap, {}, 'the urlMap was cleared after the close call');
 });
 
-test('that callback functions can be added to the listeners object', t => {
+test('that callback functions can be added and removed from the listeners object', t => {
   const myServer = new Server('ws://not-real/');
 
-  myServer.on('message', () => {});
-  myServer.on('close', () => {});
+  const onMessage = () => {};
+  const onError = () => {};
+  myServer.on('message', onMessage);
+  myServer.on('close', onError);
 
   t.is(myServer.listeners.message.length, 1);
   t.is(myServer.listeners.close.length, 1);
+
+  myServer.off('message', onMessage);
+  myServer.off('close', onError);
+
+  t.is(myServer.listeners.message.length, 0);
+  t.is(myServer.listeners.close.length, 0);
 
   myServer.close();
 });


### PR DESCRIPTION
1. fix server-side socket listeners. Fixes https://github.com/thoov/mock-socket/pull/372
2. add off method to remove the listener. Fixes https://github.com/thoov/mock-socket/issues/371