### PR TITLE
The `send()` method now only throws when the socket is in the `CONNECTING` state

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -140,7 +140,8 @@ class WebSocket extends EventTarget {
 
   send(data) {
     if (this.readyState === WebSocket.CONNECTING) {
-      throw new DOMException("Failed to execute 'send' on 'WebSocket': Still in CONNECTING state");
+      // TODO: node>=17 replace with DOMException
+      throw new Error("Failed to execute 'send' on 'WebSocket': Still in CONNECTING state");
     }
 
     // TODO: handle bufferedAmount

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -139,8 +139,8 @@ class WebSocket extends EventTarget {
   }
 
   send(data) {
-    if (this.readyState === WebSocket.CLOSING || this.readyState === WebSocket.CLOSED) {
-      throw new Error('WebSocket is already in CLOSING or CLOSED state');
+    if (this.readyState === WebSocket.CONNECTING) {
+      throw new DOMException("Failed to execute 'send' on 'WebSocket': Still in CONNECTING state");
     }
 
     // TODO: handle bufferedAmount

--- a/tests/unit/server.test.js
+++ b/tests/unit/server.test.js
@@ -213,9 +213,13 @@ test.cb('that the server socket callback argument is correctly scoped: on method
   });
 
   const socket1 = new WebSocket('ws://not-real/');
+  socket1.addEventListener('open', () => {
+    socket1.send('hello1');
+  });
   const socket2 = new WebSocket('ws://not-real/');
-  socket1.send('hello1');
-  socket2.send('hello2');
+  socket2.addEventListener('open', () => {
+    socket2.send('hello2');
+  });
 });
 
 test.cb('that the server socket callback argument is correctly scoped: close method', t => {
@@ -228,9 +232,13 @@ test.cb('that the server socket callback argument is correctly scoped: close met
   });
 
   const socket1 = new WebSocket('ws://not-real/');
+  socket1.addEventListener('open', () => {
+    socket1.send('1001');
+  });
   const socket2 = new WebSocket('ws://not-real/');
-  socket1.send('1001');
-  socket2.send('1002');
+  socket2.addEventListener('open', () => {
+    socket2.send('1002');
+  });
 
   socket1.onclose = event => {
     t.is(event.code, 1001);

--- a/tests/unit/websocket.test.js
+++ b/tests/unit/websocket.test.js
@@ -76,8 +76,8 @@ test.cb('that sending when the socket is in the `CLOSED` state does not throw an
     t.notThrows(
       () => {
         mySocket.send('testing');
-        t.end();
       },
     );
+    t.end();
   }, { once: true });
 });

--- a/tests/unit/websocket.test.js
+++ b/tests/unit/websocket.test.js
@@ -76,13 +76,3 @@ test('that sending when the socket is in the `CLOSED` state does not throw an ex
     },
   );
 });
-
-test('that sending when the socket is in the `OPEN` state does not throw an exception', t => {
-  const mySocket = new WebSocket('ws://not-real', 'foo');
-  mySocket.readyState = WebSocket.OPEN;
-  t.notThrows(
-    () => {
-      mySocket.send('testing');
-    },
-  );
-});

--- a/tests/unit/websocket.test.js
+++ b/tests/unit/websocket.test.js
@@ -45,14 +45,44 @@ test('that passing protocols into the constructor works', t => {
   t.is(myOtherSocket.protocol, 'bar', 'the correct protocol is set when it was passed in as an array');
 });
 
-test('that sending when the socket is closed throws an expection', t => {
+test('that sending when the socket is in the `CONNECTING` state throws an exception', t => {
   const mySocket = new WebSocket('ws://not-real', 'foo');
-  mySocket.readyState = WebSocket.CLOSED;
+  mySocket.readyState = WebSocket.CONNECTING;
   t.throws(
     () => {
       mySocket.send('testing');
     },
-    'WebSocket is already in CLOSING or CLOSED state',
-    'an expection is thrown when sending while closed'
+    "Failed to execute 'send' on 'WebSocket': Still in CONNECTING state",
+    'an exception is thrown when sending while in the `CONNECTING` state'
+  );
+});
+
+test('that sending when the socket is in the `CLOSING` state does not throw an exception', t => {
+  const mySocket = new WebSocket('ws://not-real', 'foo');
+  mySocket.readyState = WebSocket.CLOSED;
+  t.notThrows(
+    () => {
+      mySocket.send('testing');
+    },
+  );
+});
+
+test('that sending when the socket is in the `CLOSED` state does not throw an exception', t => {
+  const mySocket = new WebSocket('ws://not-real', 'foo');
+  mySocket.readyState = WebSocket.CLOSED;
+  t.notThrows(
+    () => {
+      mySocket.send('testing');
+    },
+  );
+});
+
+test('that sending when the socket is in the `OPEN` state does not throw an exception', t => {
+  const mySocket = new WebSocket('ws://not-real', 'foo');
+  mySocket.readyState = WebSocket.OPEN;
+  t.notThrows(
+    () => {
+      mySocket.send('testing');
+    },
   );
 });

--- a/tests/unit/websocket.test.js
+++ b/tests/unit/websocket.test.js
@@ -59,7 +59,7 @@ test('that sending when the socket is in the `CONNECTING` state throws an except
 
 test('that sending when the socket is in the `CLOSING` state does not throw an exception', t => {
   const mySocket = new WebSocket('ws://not-real', 'foo');
-  mySocket.readyState = WebSocket.CLOSED;
+  mySocket.close();
   t.notThrows(
     () => {
       mySocket.send('testing');
@@ -67,12 +67,15 @@ test('that sending when the socket is in the `CLOSING` state does not throw an e
   );
 });
 
-test('that sending when the socket is in the `CLOSED` state does not throw an exception', t => {
+test.cb('that sending when the socket is in the `CLOSED` state does not throw an exception', t => {
   const mySocket = new WebSocket('ws://not-real', 'foo');
-  mySocket.readyState = WebSocket.CLOSED;
-  t.notThrows(
-    () => {
-      mySocket.send('testing');
-    },
-  );
+  mySocket.close();
+  mySocket.addEventListener('close', () => {
+    t.notThrows(
+      () => {
+        mySocket.send('testing');
+        t.end();
+      },
+    );
+  }, { once: true });
 });

--- a/tests/unit/websocket.test.js
+++ b/tests/unit/websocket.test.js
@@ -47,7 +47,7 @@ test('that passing protocols into the constructor works', t => {
 
 test('that sending when the socket is in the `CONNECTING` state throws an exception', t => {
   const mySocket = new WebSocket('ws://not-real', 'foo');
-  mySocket.readyState = WebSocket.CONNECTING;
+  t.is(mySocket.readyState, WebSocket.CONNECTING);
   t.throws(
     () => {
       mySocket.send('testing');
@@ -60,6 +60,7 @@ test('that sending when the socket is in the `CONNECTING` state throws an except
 test('that sending when the socket is in the `CLOSING` state does not throw an exception', t => {
   const mySocket = new WebSocket('ws://not-real', 'foo');
   mySocket.close();
+  t.is(mySocket.readyState, WebSocket.CLOSING);
   t.notThrows(
     () => {
       mySocket.send('testing');
@@ -71,6 +72,7 @@ test.cb('that sending when the socket is in the `CLOSED` state does not throw an
   const mySocket = new WebSocket('ws://not-real', 'foo');
   mySocket.close();
   mySocket.addEventListener('close', () => {
+    t.is(mySocket.readyState, WebSocket.CLOSED);
     t.notThrows(
       () => {
         mySocket.send('testing');


### PR DESCRIPTION
Fixes #377 and #381.