### PR TITLE
Calling `close` in the `CONNECTING` state should not cause `onopen` to be called

### DIFF
--- a/src/websocket.js
+++ b/src/websocket.js
@@ -51,6 +51,9 @@ class WebSocket extends EventTarget {
      * registered :-)
      */
     delay(function delayCallback() {
+      if (this.readyState !== WebSocket.CONNECTING) {
+        return;
+      }
       if (server) {
         if (
           server.options.verifyClient &&

--- a/tests/functional/close-algorithm.test.js
+++ b/tests/functional/close-algorithm.test.js
@@ -88,6 +88,10 @@ test.cb('that if the readyState is CONNECTING we fail the connection and close',
 
   mockSocket.readyState = WebSocket.CONNECTING;
 
+  mockSocket.onopen = () => {
+    t.fail('open should not have been called');
+  };
+
   mockSocket.onerror = () => {
     t.is(mockSocket.readyState, WebSocket.CLOSED);
   };


### PR DESCRIPTION
1. A test case that demonstrates the bug described in #384.
2. Code that bails out of the constructor's delayed setup in the event that the socket is no longer in the `CONNECTING` state.

Fixes #384.