### PR TITLE
Types: on* callbacks can be null

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,10 +39,10 @@ declare module 'mock-socket' {
     readonly readyState: number;
     readonly bufferedAmount: number;
 
-    onopen: (event: Event) => void;
-    onerror: (event: Event) => void;
-    onclose: (event: CloseEvent) => void;
-    onmessage: (event: MessageEvent) => void;
+    onopen: ((event: Event) => void) | null;
+    onerror: ((event: Event) => void) | null;
+    onclose: ((event: CloseEvent) => void) | null;
+    onmessage: ((event: MessageEvent) => void) | null;
     readonly extensions: string;
     readonly protocol: string;
     close(code?: number, reason?: string): void;


### PR DESCRIPTION
The callbacks are initialized to `null`:

https://github.com/thoov/mock-socket/blob/47eab99d42b4f17abe8b7cc6ab1466cca6768750/src/websocket.js#L24-L27

This should be reflected in the type declarations.